### PR TITLE
Handle codegen changes in dust 2.6.0

### DIFF
--- a/lib/dustc-commonjs.js
+++ b/lib/dustc-commonjs.js
@@ -33,6 +33,7 @@ exports.compile = function(src, options, callback) {
         compiledSrc = compiledSrc.replace(registerRegExp, function(match, funcName) {
             return 'module.exports=' + funcName;
         });
+        compiledSrc = 'var dust = require(\'dustjs-linkedin\');' + compiledSrc;
         callback(null, compiledSrc);
     } catch(e) {
         callback(e);

--- a/package.json
+++ b/package.json
@@ -24,5 +24,5 @@
         "registry": "https://registry.npmjs.org/"
     },
     "dependencies": {},
-    "version": "1.0.1"
+    "version": "1.0.2"
 }

--- a/test/test.js
+++ b/test/test.js
@@ -23,9 +23,8 @@ describe('dustc-commonjs' , function() {
             if (err) {
                 return done(err);
             }
-            expect(src).to.equal('(function(){module.exports=body_0;function body_0(chk,ctx){return chk.write("Hello ").reference(ctx.get(["name"], false),ctx,"h").write("!");}return body_0;})();');
+            expect(src).to.equal('var dust = require(\'dustjs-linkedin\');(function(dust){module.exports=body_0;function body_0(chk,ctx){return chk.w("Hello ").f(ctx.get(["name"], false),ctx,"h").w("!");}body_0.__dustBody=!0;return body_0;})(dust);');
             done();
         });
     });
 });
-


### PR DESCRIPTION
Changes in compiler for dustjs 2.6.0 to support AMD module generation also changed the form of compiled non-AMD code such that it requires passing in dust instead of assuming a global dust object. Modified to define dust local to the generated code and not create a global.  Tested loading sample-app-ebay home page with this change and using 2.5/1.5 dust plus 2.6/1.6 versions. Both worked.
